### PR TITLE
fix: use entity_id as unique key for value restoration

### DIFF
--- a/.changeset/fix-duplicate-names.md
+++ b/.changeset/fix-duplicate-names.md
@@ -1,0 +1,5 @@
+---
+'ha-treemap-card': patch
+---
+
+Fixed entities with the same name displaying incorrect values

--- a/src/utils/data.ts
+++ b/src/utils/data.ts
@@ -49,15 +49,15 @@ export function prepareTreemapData(
   // Apply inverse sizing (low values get bigger rectangles)
   if (inverse) {
     const sizeSum = sizeMaxVal + sizeMinVal;
-    for (const d of data) {
-      d.sizeValue = sizeSum - d.sizeValue;
+    for (const item of data) {
+      item.sizeValue = sizeSum - item.sizeValue;
     }
     // Recalculate max after inversion for min floor calculation
     sizeMaxVal = sizeSum - sizeMinVal;
     const minFloor = sizeMaxVal * 0.1;
-    for (const d of data) {
-      if (d.sizeValue < minFloor) {
-        d.sizeValue = minFloor;
+    for (const item of data) {
+      if (item.sizeValue < minFloor) {
+        item.sizeValue = minFloor;
       }
     }
   }
@@ -74,20 +74,20 @@ export function prepareTreemapData(
 
   // Apply size constraints in single pass, also find currentMax
   let currentMax = 1;
-  for (const d of limitedData) {
-    if (sizeMax !== undefined && d.sizeValue > sizeMax) {
-      d.sizeValue = sizeMax;
+  for (const item of limitedData) {
+    if (sizeMax !== undefined && item.sizeValue > sizeMax) {
+      item.sizeValue = sizeMax;
     }
-    if (d.sizeValue > currentMax) {
-      currentMax = d.sizeValue;
+    if (item.sizeValue > currentMax) {
+      currentMax = item.sizeValue;
     }
   }
 
   // Apply min floor (default: 15% of max sizeValue)
   const effectiveMin = sizeMin ?? currentMax * 0.15;
-  for (const d of limitedData) {
-    if (d.sizeValue < effectiveMin) {
-      d.sizeValue = effectiveMin;
+  for (const item of limitedData) {
+    if (item.sizeValue < effectiveMin) {
+      item.sizeValue = effectiveMin;
     }
   }
 

--- a/src/utils/sparkline.test.ts
+++ b/src/utils/sparkline.test.ts
@@ -26,7 +26,7 @@ describe('getSparklinePoints', () => {
 
     // All y values should be the same (middle of chart)
     const points = linePoints.split(' ');
-    const yValues = points.map(p => Number.parseFloat(p.split(',')[1] ?? '0'));
+    const yValues = points.map(point => Number.parseFloat(point.split(',')[1] ?? '0'));
     expect(new Set(yValues).size).toBe(1);
   });
 
@@ -50,7 +50,7 @@ describe('getSparklinePoints', () => {
     const { linePoints } = getSparklinePoints(data, { width: 100, height: 20 });
 
     const points = linePoints.split(' ');
-    const yValues = points.map(p => Number.parseFloat(p.split(',')[1] ?? '0'));
+    const yValues = points.map(point => Number.parseFloat(point.split(',')[1] ?? '0'));
 
     // Min y should be close to 1 (top padding), max close to 19 (bottom - padding)
     expect(Math.min(...yValues)).toBeCloseTo(1, 0);
@@ -65,7 +65,7 @@ describe('getSparklinePoints', () => {
     expect(points).toHaveLength(3);
 
     // Should normalize to height range
-    const yValues = points.map(p => Number.parseFloat(p.split(',')[1] ?? '0'));
+    const yValues = points.map(point => Number.parseFloat(point.split(',')[1] ?? '0'));
     expect(Math.min(...yValues)).toBeGreaterThanOrEqual(0);
     expect(Math.max(...yValues)).toBeLessThanOrEqual(20);
   });
@@ -77,7 +77,7 @@ describe('getSparklinePoints', () => {
     const points = linePoints.split(' ');
     expect(points).toHaveLength(11);
 
-    const xValues = points.map(p => Number.parseFloat(p.split(',')[0] ?? '0'));
+    const xValues = points.map(point => Number.parseFloat(point.split(',')[0] ?? '0'));
     // First x should be 0, last should be 100
     expect(xValues[0]).toBe(0);
     expect(xValues[10]).toBe(100);
@@ -121,7 +121,7 @@ describe('renderSparkline', () => {
 
     expect(result).toHaveProperty('strings');
     // Should have nothing values for hidden fill
-    const nothingCount = result.values.filter(v => v === nothing).length;
+    const nothingCount = result.values.filter(value => value === nothing).length;
     expect(nothingCount).toBeGreaterThanOrEqual(1);
   });
 

--- a/src/utils/squarify.test.ts
+++ b/src/utils/squarify.test.ts
@@ -234,7 +234,7 @@ describe('squarify', () => {
 
     expect(result).toHaveLength(4);
     // All items should be placed
-    expect(result.map(r => r.label).sort()).toEqual(['A', 'B', 'C', 'D']);
+    expect(result.map(rect => rect.label).sort()).toEqual(['A', 'B', 'C', 'D']);
   });
 
   it('corrects extremely wide rectangles', () => {

--- a/src/utils/squarify.ts
+++ b/src/utils/squarify.ts
@@ -39,7 +39,7 @@ function layoutRow(
   container: Container,
   vertical: boolean
 ): { rects: TreemapRect[]; remaining: Container } {
-  const sum = row.reduce((accumulator, r) => accumulator + r.normalizedValue, 0);
+  const sum = row.reduce((accumulator, entry) => accumulator + entry.normalizedValue, 0);
 
   const rects: TreemapRect[] = [];
   let offset = 0;
@@ -47,18 +47,18 @@ function layoutRow(
   if (vertical) {
     const rowWidth = sum / container.height;
 
-    for (const r of row) {
-      const height = r.normalizedValue / rowWidth;
+    for (const entry of row) {
+      const height = entry.normalizedValue / rowWidth;
       rects.push({
-        label: r.item.label,
-        value: r.item.value,
-        sizeValue: r.item.sizeValue,
-        colorValue: r.item.colorValue,
-        entity_id: r.item.entity_id,
-        icon: r.item.icon,
-        light: r.item.light,
-        climate: r.item.climate,
-        sparklineData: r.item.sparklineData,
+        label: entry.item.label,
+        value: entry.item.value,
+        sizeValue: entry.item.sizeValue,
+        colorValue: entry.item.colorValue,
+        entity_id: entry.item.entity_id,
+        icon: entry.item.icon,
+        light: entry.item.light,
+        climate: entry.item.climate,
+        sparklineData: entry.item.sparklineData,
         x: container.x,
         y: container.y + offset,
         width: rowWidth,
@@ -79,18 +79,18 @@ function layoutRow(
   } else {
     const rowHeight = sum / container.width;
 
-    for (const r of row) {
-      const width = r.normalizedValue / rowHeight;
+    for (const entry of row) {
+      const width = entry.normalizedValue / rowHeight;
       rects.push({
-        label: r.item.label,
-        value: r.item.value,
-        sizeValue: r.item.sizeValue,
-        colorValue: r.item.colorValue,
-        entity_id: r.item.entity_id,
-        icon: r.item.icon,
-        light: r.item.light,
-        climate: r.item.climate,
-        sparklineData: r.item.sparklineData,
+        label: entry.item.label,
+        value: entry.item.value,
+        sizeValue: entry.item.sizeValue,
+        colorValue: entry.item.colorValue,
+        entity_id: entry.item.entity_id,
+        icon: entry.item.icon,
+        light: entry.item.light,
+        climate: entry.item.climate,
+        sparklineData: entry.item.sparklineData,
         x: container.x + offset,
         y: container.y,
         width,
@@ -194,7 +194,9 @@ export function squarify(
 
   // Compress range using sqrt so small values are still visible
   // sqrt(1) = 1, sqrt(100) = 10, so 1% becomes 10% of max instead of 1%
-  const sizeValues = compressRange ? absValues.map(v => Math.sqrt(v / maxAbs) * maxAbs) : absValues;
+  const sizeValues = compressRange
+    ? absValues.map(absValue => Math.sqrt(absValue / maxAbs) * maxAbs)
+    : absValues;
 
   const totalSizeValue = sizeValues.reduce((a, b) => a + b, 0);
 

--- a/tests/sensors.test.ts
+++ b/tests/sensors.test.ts
@@ -383,6 +383,37 @@ describe('Sensor Entities', () => {
     expect(smallArea).toBeCloseTo(zeroArea, 0);
   });
 
+  it('renders correct values for entities with duplicate friendly_names', async () => {
+    const hass = mockHass([
+      mockEntity('sensor.plant_1_moisture', '52', {
+        friendly_name: 'Antúrio',
+        unit_of_measurement: '%',
+      }),
+      mockEntity('sensor.plant_2_moisture', '78', {
+        friendly_name: 'Antúrio',
+        unit_of_measurement: '%',
+      }),
+    ]);
+
+    card.setConfig({
+      type: 'custom:treemap-card',
+      entities: ['sensor.plant_*'],
+    });
+    card.hass = hass;
+    await card.updateComplete;
+
+    const items = getRenderedItems(card);
+
+    // Both entities should be rendered
+    expect(items).toHaveLength(2);
+
+    // Both have the same label, so we need to check that BOTH values exist
+    // (not that one value appears twice)
+    const values = items.map(i => i.value).sort((a, b) => a - b);
+    expect(values[0]).toBeCloseTo(52, 0);
+    expect(values[1]).toBeCloseTo(78, 0);
+  });
+
   it('ignores size.min and size.max when size.equal is true', async () => {
     const hass = mockHass([
       mockEntity('sensor.large', '1000', { friendly_name: 'Large' }),


### PR DESCRIPTION
- Fix #13: entities with same friendly_name now display correct values
- Use entity_id instead of label as Map key for value restoration
- Falls back to label for JSON mode (no entity_id)
- Rename single-letter variables to descriptive names (d->item, r->rect/entry, v->value, p->point)