### PR TITLE
feat: sparkline fixed Y-axis min/max bounds

### DIFF
--- a/.changeset/sparkline-min-max.md
+++ b/.changeset/sparkline-min-max.md
@@ -1,0 +1,5 @@
+---
+'ha-treemap-card': patch
+---
+
+Sparklines now support fixed Y-axis bounds via `sparkline.min` and `sparkline.max`. Useful when sensor values change only slightly — instead of a flat line filling the full chart, you can set `min: 0` and `max: 100` to show the actual position within a meaningful range.

--- a/src/editor/treemap-card-editor.ts
+++ b/src/editor/treemap-card-editor.ts
@@ -414,6 +414,22 @@ export class TreemapCardEditor extends LitElement implements LovelaceCardEditor 
               />
               <span>${this._t('editor.sparkline.show_hvac')}</span>
             </label>
+            <div class="field-row">
+              <ha-textfield
+                type="number"
+                label=${this._t('editor.sparkline.min')}
+                .value=${this._config.sparkline?.min ?? ''}
+                @input=${(e: Event) => this._handleNumberChange('sparkline.min', e)}
+                placeholder=${this._t('editor.colors.auto')}
+              ></ha-textfield>
+              <ha-textfield
+                type="number"
+                label=${this._t('editor.sparkline.max')}
+                .value=${this._config.sparkline?.max ?? ''}
+                @input=${(e: Event) => this._handleNumberChange('sparkline.max', e)}
+                placeholder=${this._t('editor.colors.auto')}
+              ></ha-textfield>
+            </div>
             ${this._renderDocsLink('sparkline')}
           </div>
         </ha-expansion-panel>

--- a/src/translations/de.json
+++ b/src/translations/de.json
@@ -44,7 +44,9 @@
       "mode_light": "Hell",
       "show_line": "Linie anzeigen",
       "show_fill": "Füllung anzeigen",
-      "show_hvac": "HVAC-Balken anzeigen (Klimaentitäten)"
+      "show_hvac": "HVAC-Balken anzeigen (Klimaentitäten)",
+      "min": "Y-Achse Min",
+      "max": "Y-Achse Max"
     },
     "colors": {
       "title": "Farben",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -44,7 +44,9 @@
       "mode_light": "Light",
       "show_line": "Show line",
       "show_fill": "Show fill",
-      "show_hvac": "Show HVAC bars (climate entities)"
+      "show_hvac": "Show HVAC bars (climate entities)",
+      "min": "Y-axis min",
+      "max": "Y-axis max"
     },
     "colors": {
       "title": "Colors",

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -44,7 +44,9 @@
       "mode_light": "Clair",
       "show_line": "Afficher la ligne",
       "show_fill": "Afficher le remplissage",
-      "show_hvac": "Afficher les barres HVAC (entités climatiques)"
+      "show_hvac": "Afficher les barres HVAC (entités climatiques)",
+      "min": "Min axe Y",
+      "max": "Max axe Y"
     },
     "colors": {
       "title": "Couleurs",

--- a/src/treemap-card.ts
+++ b/src/treemap-card.ts
@@ -910,6 +910,8 @@ export class TreemapCard extends LitElement {
                   fill: this._config?.sparkline?.fill,
                   hvac: this._config?.sparkline?.hvac,
                   periodHours: this._getPeriodHours(),
+                  min: this._config?.sparkline?.min,
+                  max: this._config?.sparkline?.max,
                 })}
               </div>`;
             })()

--- a/src/types.ts
+++ b/src/types.ts
@@ -188,6 +188,8 @@ export interface TreemapCardConfig {
     attribute?: string; // Field/attribute containing sparkline data array (JSON mode)
     period?: '12h' | '24h' | '7d' | '30d'; // Time period for entity history (default: '24h')
     mode?: 'light' | 'dark'; // Color mode (default: 'dark')
+    min?: number; // Fixed Y-axis minimum (default: auto from data)
+    max?: number; // Fixed Y-axis maximum (default: auto from data)
     line?: {
       show?: boolean; // Show line (default: true)
       style?: string; // Custom CSS for line (stroke, stroke-width, etc.)

--- a/src/utils/sparkline.test.ts
+++ b/src/utils/sparkline.test.ts
@@ -84,6 +84,56 @@ describe('getSparklinePoints', () => {
     // Spacing should be even (10 intervals for 11 points)
     expect(xValues[1]).toBeCloseTo(10, 0);
   });
+
+  it('uses fixed min when provided', () => {
+    const data = [10, 50, 90];
+    // With min=0, the value 10 should NOT appear at the bottom of the chart
+    const { linePoints: autoPoints } = getSparklinePoints(data, { width: 100, height: 20 });
+    const { linePoints: fixedPoints } = getSparklinePoints(data, {
+      width: 100,
+      height: 20,
+      min: 0,
+    });
+
+    const getY = (pts: string, idx: number) =>
+      Number.parseFloat(pts.split(' ')[idx]?.split(',')[1] ?? '0');
+
+    // With fixed min=0 (lower than data min=10), value 10 is no longer at the bottom,
+    // so it appears visually higher — smaller y in SVG coords
+    expect(getY(fixedPoints, 0)).toBeLessThan(getY(autoPoints, 0));
+  });
+
+  it('uses fixed max when provided', () => {
+    const data = [10, 50, 90];
+    // With max=100, the value 90 should NOT appear at the top of the chart
+    const { linePoints: autoPoints } = getSparklinePoints(data, { width: 100, height: 20 });
+    const { linePoints: fixedPoints } = getSparklinePoints(data, {
+      width: 100,
+      height: 20,
+      max: 100,
+    });
+
+    const getY = (pts: string, idx: number) =>
+      Number.parseFloat(pts.split(' ')[idx]?.split(',')[1] ?? '0');
+
+    // With fixed max=100 (higher than data max=90), last point y should be lower (not at top)
+    expect(getY(fixedPoints, 2)).toBeGreaterThan(getY(autoPoints, 2));
+  });
+
+  it('fixed min/max produces flat line when data is within narrow range', () => {
+    // Sensor stuck at 21°C, but chart shows 0-30 range — should show near-flat line in middle
+    const data = [21, 21, 21, 21];
+    const { linePoints } = getSparklinePoints(data, { width: 100, height: 20, min: 0, max: 30 });
+
+    const points = linePoints.split(' ');
+    const yValues = points.map(point => Number.parseFloat(point.split(',')[1] ?? '0'));
+    // All y values should be the same (flat line)
+    expect(new Set(yValues.map(y => y.toFixed(1))).size).toBe(1);
+    // And NOT at top or bottom (should be around 70% down: 21/30 = 0.7)
+    const y = yValues[0] ?? 0;
+    expect(y).toBeGreaterThan(5);
+    expect(y).toBeLessThan(15);
+  });
 });
 
 describe('renderSparkline', () => {

--- a/src/utils/sparkline.ts
+++ b/src/utils/sparkline.ts
@@ -25,6 +25,8 @@ export interface SparklineOptions {
   fill?: SparklineFillOptions;
   hvac?: SparklineHvacOptions;
   periodHours?: number; // For HVAC quantization (default: 24)
+  min?: number; // Fixed Y-axis minimum (default: auto from data)
+  max?: number; // Fixed Y-axis maximum (default: auto from data)
 }
 
 /**
@@ -39,8 +41,8 @@ export function getSparklinePoints(
   const verticalPadding = 1; // Small padding top/bottom for line visibility
   const effectiveHeight = height - bottomPadding;
 
-  const minValue = Math.min(...data);
-  const maxValue = Math.max(...data);
+  const minValue = options.min ?? Math.min(...data);
+  const maxValue = options.max ?? Math.max(...data);
   const range = maxValue - minValue || 1;
 
   const linePoints = data
@@ -143,6 +145,8 @@ interface HvacFillOptions {
   height: number;
   colors: { heating: string; cooling: string };
   periodHours: number;
+  min?: number;
+  max?: number;
 }
 
 /**
@@ -156,8 +160,8 @@ function renderHvacFill(options: HvacFillOptions): SVGTemplateResult {
   const totalBlocks = blocks.length;
 
   // Calculate min/max for y-scaling
-  const minValue = Math.min(...data);
-  const maxValue = Math.max(...data);
+  const minValue = options.min ?? Math.min(...data);
+  const maxValue = options.max ?? Math.max(...data);
   const range = maxValue - minValue || 1;
   const verticalPadding = 1;
 
@@ -267,7 +271,7 @@ export function renderSparkline(
       `
           : nothing
       }
-      ${showHvac && hasData ? renderHvacFill({ segments: hvacActions, data, width, height, colors: hvacColors, periodHours }) : nothing}
+      ${showHvac && hasData ? renderHvacFill({ segments: hvacActions, data, width, height, colors: hvacColors, periodHours, min: options.min, max: options.max }) : nothing}
       ${showFill && !hvacActions ? svg`<polygon points="${fillPoints}" style="${fillStyle}" />` : nothing}
       ${showLine ? svg`<polyline points="${linePoints}" style="fill: none; stroke-linecap: round; stroke-linejoin: round; ${lineStyle}" />` : nothing}
     </svg>


### PR DESCRIPTION
- Add `sparkline.min` and `sparkline.max` config options for fixed Y-axis bounds
- Useful when sensor values vary little — prevents flat-line effect by anchoring the chart to a meaningful range (e.g. `min: 0, max: 100` for a temperature that stays around 21°C)
- Min/max inputs added to the Sparkline panel in the visual editor
- Translations updated (en, de, fr)
- Closes #47