### PR TITLE
fix: auto height minimum causing extra empty space

### DIFF
--- a/.changeset/auto-height-fix.md
+++ b/.changeset/auto-height-fix.md
@@ -1,5 +1,5 @@
 ---
-"ha-treemap-card": patch
+'ha-treemap-card': patch
 ---
 
 Fixed auto height adding an extra empty row when displaying only a few entities. Cards with a single entity or a small number of entities now size correctly without phantom whitespace at the bottom.

--- a/.changeset/auto-height-fix.md
+++ b/.changeset/auto-height-fix.md
@@ -1,0 +1,5 @@
+---
+"ha-treemap-card": patch
+---
+
+Fixed auto height adding an extra empty row when displaying only a few entities. Cards with a single entity or a small number of entities now size correctly without phantom whitespace at the bottom.

--- a/src/treemap-card.ts
+++ b/src/treemap-card.ts
@@ -713,7 +713,7 @@ export class TreemapCard extends LitElement {
 
     // Dynamic height based on actual row count from squarify algorithm
     const numberRows = Math.max(1, rows);
-    const baseHeight = Math.max(150, numberRows * 100); // 100px per row, min 150px
+    const baseHeight = Math.max(100, numberRows * 100); // 100px per row, min 100px
     const height = this._config.height ?? baseHeight;
     const gap = this._config.gap ?? 6;
 


### PR DESCRIPTION
- Drop auto-height minimum from `150px` to `100px` (= 1 row)
- The 150px floor was causing ~50px of phantom whitespace at the bottom of cards with very few entities
- Reproduced and confirmed via measurement: 1-entity card had `containerHeight: 150px` vs expected `100px`
- Closes #46