### PR TITLE
fix: sort_by "default" now preserves config entity order

### DIFF
--- a/.changeset/sort-by-default-fix.md
+++ b/.changeset/sort-by-default-fix.md
@@ -1,0 +1,5 @@
+---
+"ha-treemap-card": patch
+---
+
+Fixed `sort_by: default` not preserving config entity order

--- a/src/treemap-card.ts
+++ b/src/treemap-card.ts
@@ -664,6 +664,7 @@ export class TreemapCard extends LitElement {
       limit: this._config?.limit,
       sizeMin: this._config?.size?.min,
       sizeMax: this._config?.size?.max,
+      sortBy: this._config?.sort_by ?? 'value',
     });
 
     // Generate treemap layout using sizeValue

--- a/src/utils/data.ts
+++ b/src/utils/data.ts
@@ -11,6 +11,7 @@ export interface PrepareDataOptions {
   limit?: number;
   sizeMin?: number;
   sizeMax?: number;
+  sortBy?: string;
 }
 
 export interface PreparedData {
@@ -123,7 +124,7 @@ export function prepareTreemapData(
   data: TreemapItem[],
   options: PrepareDataOptions = {}
 ): PreparedData {
-  const { inverse = false, ascending = false, limit, sizeMin, sizeMax } = options;
+  const { inverse = false, ascending = false, limit, sizeMin, sizeMax, sortBy } = options;
 
   if (data.length === 0) {
     return { items: [], colorMin: 0, colorMax: 0 };
@@ -148,8 +149,25 @@ export function prepareTreemapData(
   }
 
   // Sort and limit
-  const sortedData = sortBySize(data, inverse, ascending);
-  const limitedData = limit !== undefined && limit > 0 ? sortedData.slice(0, limit) : sortedData;
+  // When sortBy is NOT 'value', preserve original input order for squarify.
+  // We still need to sort temporarily for limit slicing (to pick the top-N items),
+  // but then restore the original order.
+  const needsValueSort = !sortBy || sortBy === 'value';
+
+  let limitedData: TreemapItem[];
+  if (needsValueSort) {
+    // Default behavior: sort by size value for both layout and limit
+    const sortedData = sortBySize(data, inverse, ascending);
+    limitedData = limit !== undefined && limit > 0 ? sortedData.slice(0, limit) : sortedData;
+  } else if (limit !== undefined && limit > 0) {
+    // Non-value sort with limit: sort to pick top-N, then restore original order
+    const sortedData = sortBySize(data, inverse, ascending);
+    const topN = new Set(sortedData.slice(0, limit).map(item => item.entity_id ?? item.label));
+    limitedData = data.filter(item => topN.has(item.entity_id ?? item.label));
+  } else {
+    // Non-value sort without limit: preserve original order
+    limitedData = [...data];
+  }
 
   // Apply size constraints
   const currentMax = applySizeMax(limitedData, sizeMax);

--- a/tests/sensors.test.ts
+++ b/tests/sensors.test.ts
@@ -1039,12 +1039,7 @@ describe('Sensor Entities', () => {
 
     card.setConfig({
       type: 'custom:treemap-card',
-      entities: [
-        'sensor.cpu_din',
-        'sensor.cpu_boba',
-        'sensor.cpu_armorer',
-        'sensor.cpu_kuiil',
-      ],
+      entities: ['sensor.cpu_din', 'sensor.cpu_boba', 'sensor.cpu_armorer', 'sensor.cpu_kuiil'],
       sort_by: 'default',
     });
     card.hass = hass;

--- a/tests/sensors.test.ts
+++ b/tests/sensors.test.ts
@@ -1021,6 +1021,59 @@ describe('Sensor Entities', () => {
     expect(negArea).toBeLessThan(midArea);
     expect(midArea).toBeLessThan(bigArea);
   });
+
+  it('preserves config entity order with sort_by: "default"', async () => {
+    // Bug: prepareTreemapData() unconditionally calls sortBySize(), which
+    // reorders items by value BEFORE squarify sees them. Even though squarify's
+    // normalizeAndSort() correctly skips sorting for sortBy === 'default',
+    // it receives already-sorted data so the config order is lost.
+    //
+    // This test uses entities whose values are NOT in config order to detect
+    // whether the pipeline preserves the original order.
+    const hass = mockHass([
+      mockEntity('sensor.cpu_din', '35', { friendly_name: 'Din CPU' }),
+      mockEntity('sensor.cpu_boba', '82', { friendly_name: 'Boba CPU' }),
+      mockEntity('sensor.cpu_armorer', '10', { friendly_name: 'Armorer CPU' }),
+      mockEntity('sensor.cpu_kuiil', '55', { friendly_name: 'Kuiil CPU' }),
+    ]);
+
+    card.setConfig({
+      type: 'custom:treemap-card',
+      entities: [
+        'sensor.cpu_din',
+        'sensor.cpu_boba',
+        'sensor.cpu_armorer',
+        'sensor.cpu_kuiil',
+      ],
+      sort_by: 'default',
+    });
+    card.hass = hass;
+    await card.updateComplete;
+
+    const items = getRenderedItems(card);
+    expect(items).toHaveLength(4);
+
+    const din = items.find(i => i.label === 'Din CPU');
+    const boba = items.find(i => i.label === 'Boba CPU');
+    const armorer = items.find(i => i.label === 'Armorer CPU');
+    const kuiil = items.find(i => i.label === 'Kuiil CPU');
+
+    expect(din).toBeDefined();
+    expect(boba).toBeDefined();
+    expect(armorer).toBeDefined();
+    expect(kuiil).toBeDefined();
+
+    // With sort_by: "default", tile positions should follow config order:
+    // Din (first/top-left), Boba (second), Armorer (third), Kuiil (last/bottom-right)
+    const dinPos = din!.y * 1000 + din!.x;
+    const bobaPos = boba!.y * 1000 + boba!.x;
+    const armorerPos = armorer!.y * 1000 + armorer!.x;
+    const kuiilPos = kuiil!.y * 1000 + kuiil!.x;
+
+    expect(dinPos).toBeLessThan(bobaPos);
+    expect(bobaPos).toBeLessThan(armorerPos);
+    expect(armorerPos).toBeLessThan(kuiilPos);
+  });
 });
 
 describe('Per-entity color override', () => {


### PR DESCRIPTION
## Summary

- `prepareTreemapData()` unconditionally sorted items by value before squarify saw them, destroying config order even when `sort_by: "default"` was set
- Added `sortBy` option to `PrepareDataOptions` — sorting is now skipped when `sortBy` is not `"value"`
- When `limit` is used with non-value sort, items are temporarily sorted for top-N selection then restored to original order
- Added integration test covering `sort_by: "default"` with 4 entities whose values don't match config order